### PR TITLE
Support other osm servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ You will obviously have to put in your key and secret, which you get when you re
 
 Now just follow the README at: https://github.com/intridea/omniauth
 
+## Other Servers
+
+If you would like to use this plugin against another OSM server, such as the test development server you can use the environment variable OSM_AUTH_SITE to set the server to connect to.
+
+You could for example use the gem figaro to configure the environment variable, or roll your own preinitialiser similar to the OpenStreetMap website.
+
 ## Note on Patches/Pull Requests
 
 - Fork the project.

--- a/lib/omniauth/strategies/osm.rb
+++ b/lib/omniauth/strategies/osm.rb
@@ -6,7 +6,15 @@ module OmniAuth
     class Osm < OmniAuth::Strategies::OAuth
       option :name, "osm"
 
-      option :client_options, :site => 'http://www.openstreetmap.org'
+      def self.site
+        if ENV['OSM_AUTH_SITE']
+          ENV['OSM_AUTH_SITE']
+        else
+          "http://www.openstreetmap.org"
+        end
+      end
+
+      option :client_options, :site => site
       option :fetch_permissions, false
 
       uid { raw_info['id'] }

--- a/spec/omniauth/strategies/osm_spec.rb
+++ b/spec/omniauth/strategies/osm_spec.rb
@@ -113,7 +113,7 @@ EOX
 
     it "initializes raw_info properly if no xml is returned" do
       response_body = "foo bar"
-      access_token = mock(:get => mock(:body => response_body))
+      access_token = double(:get => double(:body => response_body))
       subject.should_receive(:access_token).and_return(access_token)
 
       subject.raw_info.should eq({"languages" => []})

--- a/spec/omniauth/strategies/osm_spec.rb
+++ b/spec/omniauth/strategies/osm_spec.rb
@@ -13,8 +13,15 @@ describe OmniAuth::Strategies::Osm do
   end
 
   describe '#client_options' do
-    it 'has correct Osm site' do
-      subject.options.client_options.site.should eq('http://www.openstreetmap.org')
+    it 'has correct default production site' do
+      OmniAuth::Strategies::Osm.site.should eq('http://www.openstreetmap.org')
+    end
+
+    it 'should use the correct environment site override' do
+      stub_const("ENV", {'OSM_AUTH_SITE' => 'http://api06.dev.openstreetmap.org'})
+      # Can't test the subject directly here as the site was set on class load,
+      # but could still override it via an options hash if you wanted to
+      OmniAuth::Strategies::Osm.site.should eq('http://api06.dev.openstreetmap.org')
     end
   end
 


### PR DESCRIPTION
I've created a patch that allows you to configure the use of other OSM servers, such as the test server api06.dev.openstreetmap.org which is specifically for testing of software interacting with OSM before acting on production.

I've also fixed a deprecation warning on the tests, and included a test for the change.
